### PR TITLE
feat: GIF for README + MP4 for website

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 ### Demo
 
 <p align="center">
-  <video src="assets/ISC_Video.mp4" width="800" autoplay muted loop playsinline></video>
+  <img src="assets/ISC_Video.gif" width="800">
 </p>
 
 ---

--- a/assets/ISC_Video.gif
+++ b/assets/ISC_Video.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a1e24fd141da7c9cb34dac30c5ea8c4c32c9a5b987046254102439e2aa61743
+size 404333124


### PR DESCRIPTION
- README keeps GIF (386MB, LFS)
- Website uses MP4 (14MB, fast load)
- Both same content, different formats