### PR TITLE
fix: progress chart, SKILL.md callout, Chinese README sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@
 
 Coverage of [Arena Leaderboard](https://arena.ai/leaderboard) — updated 2026-03-26. **17 / 330 confirmed under ISC.**
 
+<p align="center">
+  <img src="assets/leaderboard_progress.svg" width="80%">
+</p>
+
 > **Found ISC on an untested model?** [Submit via GitHub Issue →](https://github.com/wuyoscar/ISC-Bench/issues/new?template=isc-submission.md&title=[ISC]+Model+Name) — we'll verify and add you to the leaderboard.
 >
 > **Rules**: Rankings are synced with [Arena](https://arena.ai/leaderboard) weekly. Submit your ISC case via the [issue template](.github/ISSUE_TEMPLATE/isc-submission.md) — include a public conversation link, the type of harmful content generated, and the domain. ISC is a low-conditional design concept — just a professional task that causes models to generate harmful content on their own. See our [paper](paper.pdf) for details.

--- a/scripts/gen_leaderboard.py
+++ b/scripts/gen_leaderboard.py
@@ -170,10 +170,18 @@ def main() -> None:
     # Extended table (rest)
     ext_rows = [gen_row(m, isc_cases) for m in arena[args.top:]]
 
+    chart = (
+        '<p align="center">\n'
+        '  <img src="assets/leaderboard_progress.svg" width="80%">\n'
+        '</p>'
+    )
+
     lines = [
         "## 🏆 JailbreakArena",
         "",
         header,
+        "",
+        chart,
         "",
         rules,
         "",


### PR DESCRIPTION
- Restore leaderboard progress chart (was missing after gen_leaderboard.py run)
- gen_leaderboard.py now auto-embeds chart in output
- SKILL.md callout in code block above Recent News
- Chinese README synced: Project Website, Leaderboard links, SKILL.md hint, fix duplicate arXiv badge
- Remove website Chinese link from hero