### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -60,4 +60,5 @@ authors:
     - family-names: "Jiang"
       given-names: "Yu-Gang"
   year: 2026
+  journal: "arXiv preprint arXiv:2603.23509"
   url: "https://arxiv.org/abs/2603.23509"


### PR DESCRIPTION
## Summary
- Adds `CITATION.cff` for the arxiv paper (2603.23509) with all 10 authors and ORCIDs where available
- Uses `type: article` for the arxiv preprint preferred citation

## Test plan
- [ ] Verify CITATION.cff renders correctly on GitHub repo landing page
- [ ] Confirm "Cite this repository" button appears in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)