### PR TITLE
Add Embodied AI Safety survey to news and related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 
 | Date | Update |
 |:-----|--------|
+| 📄 2026-03-27 | Our sister survey [**Safety in Embodied AI**](https://github.com/x-zheng16/Embodied-AI-Safety) is now available — a comprehensive review of 480+ papers on safety across the full embodied AI pipeline. |
 | 🎆 2026-03-27 | **500+ stars in 48 hours!** 22/330 models confirmed |
 | 🔴 2026-03-27 | [@fresh-ma](https://github.com/fresh-ma) jailbroke **Claude Sonnet 4.5 Thinking** (~20 pages of text, 42 misinformation samples), **Claude Sonnet 4.5**, and **Kimi K2.5 Instant** (~4 pages novel). [@zry29](https://github.com/zry29) jailbroke **GPT-5.4** via file upload |
 | 🔧 2026-03-27 | README overhaul + [GitHub Discussions](https://github.com/wuyoscar/ISC-Bench/discussions) now open — come chat, ask questions, share your ISC cases |
@@ -790,6 +791,11 @@ However, ISC is a **pattern**, not a fixed format. Any domain knowledge works as
 ### Contact
 
 For questions, collaborations, or responsible disclosure: **wuy⁷¹¹⁷ ⓐ 𝗴𝗺𝗮𝗶𝗹 𝗰𝗼𝗺**
+
+## Related Projects
+
+- [Safety in Embodied AI](https://github.com/x-zheng16/Embodied-AI-Safety) -- Risks, Attacks, and Defenses across the full embodied AI pipeline (480+ papers)
+- [Awesome-Large-Model-Safety](https://github.com/xingjunm/Awesome-Large-Model-Safety) -- Safety at Scale: A Comprehensive Survey of Large Model and Agent Safety
 
 ## Star History
 


### PR DESCRIPTION
## Summary

- Add our sister survey **Safety in Embodied AI** to the Recent News section (2026-03-27)
- Add a Related Projects section before Star History, linking to the Embodied AI Safety repo and Awesome-Large-Model-Safety

Cross-promotion between our team's related survey efforts.

## Changes

- **News**: one new row announcing the embodied AI safety survey release
- **Related Projects**: new section with links to Embodied-AI-Safety and Awesome-Large-Model-Safety repos