### PR TITLE
fix: point Rank 2 & 3 leaderboard links to community evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ This table tracks **publicly archived cases in this repo**, not every internal t
 | Rank | Model | Arena Score | Jailbroken | Link | By |
 |:----:|-------|:-----:|:------:|:----:|:--:|
 | 1 | <img src="https://www.google.com/s2/favicons?domain=anthropic.com&sz=32" width="14"> Claude Opus 4.6 Thinking | 1502 | 🟢 |  |  |
-| 2 | <img src="https://www.google.com/s2/favicons?domain=anthropic.com&sz=32" width="14"> Claude Opus 4.6 | 1501 | 🔴 | [🔗](https://claude.ai/share/407d33f5-4655-4479-b3e3-0a6dc6639d34) | [@wuyoscar](https://github.com/wuyoscar) |
-| 3 | <img src="https://www.google.com/s2/favicons?domain=google.com&sz=32" width="14"> Gemini 3.1 Pro Preview | 1493 | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/issues/42) | [@wuyoscar](https://github.com/wuyoscar) |
+| 2 | <img src="https://www.google.com/s2/favicons?domain=anthropic.com&sz=32" width="14"> Claude Opus 4.6 | 1501 | 🔴 | [🔗](community/issue-48-claudeopus46-agent-qwenguard/) | [@wuyoscar](https://github.com/wuyoscar) |
+| 3 | <img src="https://www.google.com/s2/favicons?domain=google.com&sz=32" width="14"> Gemini 3.1 Pro Preview | 1493 | 🔴 | [🔗](community/issue-42-gemini31pro-agent-qwenguard/) | [@wuyoscar](https://github.com/wuyoscar) |
 | 4 | <img src="https://www.google.com/s2/favicons?domain=x.ai&sz=32" width="14"> Grok 4.20 Beta | 1492 | 🔴 | [🔗](https://grok.com/share/bGVnYWN5LWNvcHk_9735b6e9-5ff1-4318-b2c2-4860b6e8fb33) | [@HanxunH](https://github.com/HanxunH) |
 | 5 | <img src="https://www.google.com/s2/favicons?domain=google.com&sz=32" width="14"> Gemini 3 Pro | 1486 | 🔴 | [🔗](https://gemini.google.com/share/320bf34b0334) | [@wuyoscar](https://github.com/wuyoscar) |
 | 6 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5.4 High | 1485 | 🟢 |  |  |

--- a/assets/isc_cases.json
+++ b/assets/isc_cases.json
@@ -1,9 +1,6 @@
 {
   "Claude Opus 4.6": {
-    "demos": [
-      {"link": "https://github.com/wuyoscar/ISC-Bench/issues/48", "by": "wuyoscar"},
-      {"link": "https://claude.ai/share/407d33f5-4655-4479-b3e3-0a6dc6639d34", "by": "wuyoscar", "note": "retired"}
-    ]
+    "demos": [{"link": "community/issue-48-claudeopus46-agent-qwenguard/", "by": "wuyoscar"}]
   },
   "Claude Opus 4.5": {
     "demos": [{"link": "https://claude.ai/share/1e3e997c-0315-46f1-9cbd-37157314a7ef", "by": "wuyoscar"}]
@@ -75,6 +72,6 @@
     ]
   },
   "Gemini 3.1 Pro Preview": {
-    "demos": [{"link": "https://github.com/wuyoscar/ISC-Bench/issues/42", "by": "wuyoscar"}]
+    "demos": [{"link": "community/issue-42-gemini31pro-agent-qwenguard/", "by": "wuyoscar"}]
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,7 +207,14 @@
         </thead>
         <tbody>
           <tr>
-            <td><a href="https://github.com/wuyoscar/ISC-Bench/issues/42">#42</a></td>
+            <td><a href="https://github.com/wuyoscar/ISC-Bench/tree/main/community/issue-48-claudeopus46-agent-qwenguard">#48</a></td>
+            <td>Claude Opus 4.6</td>
+            <td>Agentic TVD — multilingual harmful completions (replaces web link)</td>
+            <td>AI Safety</td>
+            <td class="has-text-centered"><a href="https://github.com/wuyoscar">@wuyoscar</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/wuyoscar/ISC-Bench/tree/main/community/issue-42-gemini31pro-agent-qwenguard">#42</a></td>
             <td>Gemini 3.1 Pro Preview</td>
             <td>Agentic TVD — multilingual harmful completions</td>
             <td>AI Safety</td>


### PR DESCRIPTION
- Claude Opus 4.6 → community/issue-48 evidence (retired web link removed)
- Gemini 3.1 Pro Preview → community/issue-42 evidence
- Website Community Reproductions: added #48, both link to evidence dirs