### PR TITLE
fix: use full GitHub URLs for evidence links

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,11 @@
   <img src="assets/leaderboard_progress.svg" width="80%">
 </p>
 
-This table tracks **publicly archived cases in this repo**, not every internal trigger the author team has observed. Some models are still left green here because they have not yet been written up as public cases, or because we want to leave room for community submissions and independent verification.
-
 | Rank | Model | Arena Score | Jailbroken | Link | By |
 |:----:|-------|:-----:|:------:|:----:|:--:|
 | 1 | <img src="https://www.google.com/s2/favicons?domain=anthropic.com&sz=32" width="14"> Claude Opus 4.6 Thinking | 1502 | 🟢 |  |  |
-| 2 | <img src="https://www.google.com/s2/favicons?domain=anthropic.com&sz=32" width="14"> Claude Opus 4.6 | 1501 | 🔴 | [🔗](community/issue-48-claudeopus46-agent-qwenguard/) | [@wuyoscar](https://github.com/wuyoscar) |
-| 3 | <img src="https://www.google.com/s2/favicons?domain=google.com&sz=32" width="14"> Gemini 3.1 Pro Preview | 1493 | 🔴 | [🔗](community/issue-42-gemini31pro-agent-qwenguard/) | [@wuyoscar](https://github.com/wuyoscar) |
+| 2 | <img src="https://www.google.com/s2/favicons?domain=anthropic.com&sz=32" width="14"> Claude Opus 4.6 | 1501 | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/issue-48-claudeopus46-agent-qwenguard) | [@wuyoscar](https://github.com/wuyoscar) |
+| 3 | <img src="https://www.google.com/s2/favicons?domain=google.com&sz=32" width="14"> Gemini 3.1 Pro Preview | 1493 | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/issue-42-gemini31pro-agent-qwenguard) | [@wuyoscar](https://github.com/wuyoscar) |
 | 4 | <img src="https://www.google.com/s2/favicons?domain=x.ai&sz=32" width="14"> Grok 4.20 Beta | 1492 | 🔴 | [🔗](https://grok.com/share/bGVnYWN5LWNvcHk_9735b6e9-5ff1-4318-b2c2-4860b6e8fb33) | [@HanxunH](https://github.com/HanxunH) |
 | 5 | <img src="https://www.google.com/s2/favicons?domain=google.com&sz=32" width="14"> Gemini 3 Pro | 1486 | 🔴 | [🔗](https://gemini.google.com/share/320bf34b0334) | [@wuyoscar](https://github.com/wuyoscar) |
 | 6 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5.4 High | 1485 | 🟢 |  |  |

--- a/assets/isc_cases.json
+++ b/assets/isc_cases.json
@@ -1,6 +1,6 @@
 {
   "Claude Opus 4.6": {
-    "demos": [{"link": "community/issue-48-claudeopus46-agent-qwenguard/", "by": "wuyoscar"}]
+    "demos": [{"link": "https://github.com/wuyoscar/ISC-Bench/tree/main/community/issue-48-claudeopus46-agent-qwenguard", "by": "wuyoscar"}]
   },
   "Claude Opus 4.5": {
     "demos": [{"link": "https://claude.ai/share/1e3e997c-0315-46f1-9cbd-37157314a7ef", "by": "wuyoscar"}]
@@ -72,6 +72,6 @@
     ]
   },
   "Gemini 3.1 Pro Preview": {
-    "demos": [{"link": "community/issue-42-gemini31pro-agent-qwenguard/", "by": "wuyoscar"}]
+    "demos": [{"link": "https://github.com/wuyoscar/ISC-Bench/tree/main/community/issue-42-gemini31pro-agent-qwenguard", "by": "wuyoscar"}]
   }
 }


### PR DESCRIPTION
Relative paths 404 on GitHub Pages. Only changes Rank 2 + Rank 3 links.