### PR TITLE
docs: clean up README — remove Star History and Ongoing Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,19 +137,6 @@ Templates are not fixed — they are starting points. Effectiveness depends on y
 
 <sub>[Full changelog →](CHANGELOG.md)</sub>
 
-## Ongoing Work
-
-<details>
-<summary><b>Ongoing Work</b></summary>
-
-<br>
-
-**Auto-ISC** — automated evaluation pipeline for measuring ISC vulnerability at scale across frontier models. Coming soon.
-
-We are also converting each template into a more standardized scaffold so agents can edit, extend, and run them with less task-specific context.
-
-</details>
-
 ---
 
 ## 🔍 Community Perspectives

--- a/README.md
+++ b/README.md
@@ -690,12 +690,3 @@ For questions, collaborations, or responsible disclosure: **wuy⁷¹¹⁷ ⓐ �
 - [Awesome-Large-Model-Safety](https://github.com/xingjunm/Awesome-Large-Model-Safety) -- Safety at Scale: A Comprehensive Survey of Large Model and Agent Safety
 - [AI Safety Report](https://github.com/XSafeAI/AI-safety-report) -- A broad evaluation suite and report for frontier model safety across language, vision-language, and image generation
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=wuyoscar%2FISC-Bench&type=date&logscale=true&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=wuyoscar/ISC-Bench&type=date&theme=dark&logscale=true&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=wuyoscar/ISC-Bench&type=date&logscale=true&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=wuyoscar/ISC-Bench&type=date&logscale=true&legend=top-left" />
- </picture>
-</a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -682,12 +682,3 @@ For questions, collaborations, or responsible disclosure: **wuy⁷¹¹⁷ ⓐ �
 - [Awesome-Large-Model-Safety](https://github.com/xingjunm/Awesome-Large-Model-Safety) -- Safety at Scale: A Comprehensive Survey of Large Model and Agent Safety
 - [AI Safety Report](https://github.com/XSafeAI/AI-safety-report) -- A broad evaluation suite and report for frontier model safety across language, vision-language, and image generation
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=wuyoscar%2FISC-Bench&type=date&logscale=&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=wuyoscar/ISC-Bench&type=date&theme=dark&logscale&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=wuyoscar/ISC-Bench&type=date&logscale&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=wuyoscar/ISC-Bench&type=date&logscale&legend=top-left" />
- </picture>
-</a>


### PR DESCRIPTION
## Summary

- Remove Star History section from both `README.md` and `README_zh.md`
- Remove Ongoing Work section from `README.md`
- Rename section ② toggle from "The prompt" to "Minimum prompt" in both READMEs
- Remove zero-shot toggles from section ② (only full agent prompt kept)

## Test plan

- [ ] Verify Star History section is gone from both READMEs
- [ ] Verify Ongoing Work section is gone from README.md
- [ ] Verify section ② has exactly one toggle labeled "Minimum prompt"