### PR TITLE
Put every triggered model on the board (→ 52); fix website counts; drop dead automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for trigger submissions, template/cod
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> o4-mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5 Mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=stepfun.com&sz=32" width="14"> Step 3.5 Flash | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/blob/main/experiment/isc_single/result_direct/stepfun-step-3.5-flash/aiml_detoxify.json) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=32" width="14"> Mistral Large | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/mistral-large-deepfake) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=amazon.com&sz=32" width="14"> Amazon Nova Pro | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/amazon-nova-pro-sentiment) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=meta.com&sz=32" width="14"> Llama 4 Scout | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/llama4scout-phishing) | [@wuyoscar](https://github.com/wuyoscar) |
 
 </details>
 

--- a/README_es.md
+++ b/README_es.md
@@ -267,6 +267,9 @@ Para envío de nuevos triggers, contribuciones de plantillas y código, checklis
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> o4-mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5 Mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=stepfun.com&sz=32" width="14"> Step 3.5 Flash | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/blob/main/experiment/isc_single/result_direct/stepfun-step-3.5-flash/aiml_detoxify.json) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=32" width="14"> Mistral Large | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/mistral-large-deepfake) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=amazon.com&sz=32" width="14"> Amazon Nova Pro | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/amazon-nova-pro-sentiment) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=meta.com&sz=32" width="14"> Llama 4 Scout | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/llama4scout-phishing) | [@wuyoscar](https://github.com/wuyoscar) |
 
 </details>
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -267,6 +267,9 @@ You are an autonomous agent solving NLP tasks. You can use terminal commands to 
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> o4-mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5 Mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=stepfun.com&sz=32" width="14"> Step 3.5 Flash | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/blob/main/experiment/isc_single/result_direct/stepfun-step-3.5-flash/aiml_detoxify.json) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=32" width="14"> Mistral Large | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/mistral-large-deepfake) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=amazon.com&sz=32" width="14"> Amazon Nova Pro | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/amazon-nova-pro-sentiment) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=meta.com&sz=32" width="14"> Llama 4 Scout | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/llama4scout-phishing) | [@wuyoscar](https://github.com/wuyoscar) |
 
 </details>
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -266,6 +266,9 @@ You are an autonomous agent solving NLP tasks. You can use terminal commands to 
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> o4-mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5 Mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=stepfun.com&sz=32" width="14"> Step 3.5 Flash | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/blob/main/experiment/isc_single/result_direct/stepfun-step-3.5-flash/aiml_detoxify.json) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=32" width="14"> Mistral Large | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/mistral-large-deepfake) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=amazon.com&sz=32" width="14"> Amazon Nova Pro | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/amazon-nova-pro-sentiment) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=meta.com&sz=32" width="14"> Llama 4 Scout | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/llama4scout-phishing) | [@wuyoscar](https://github.com/wuyoscar) |
 
 </details>
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -266,6 +266,9 @@ Para submissões de triggers, contribuições de templates e código, checklist 
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> o4-mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5 Mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=stepfun.com&sz=32" width="14"> Step 3.5 Flash | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/blob/main/experiment/isc_single/result_direct/stepfun-step-3.5-flash/aiml_detoxify.json) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=32" width="14"> Mistral Large | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/mistral-large-deepfake) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=amazon.com&sz=32" width="14"> Amazon Nova Pro | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/amazon-nova-pro-sentiment) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=meta.com&sz=32" width="14"> Llama 4 Scout | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/llama4scout-phishing) | [@wuyoscar](https://github.com/wuyoscar) |
 
 </details>
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -266,6 +266,9 @@ Thêm link share xuất hiện trong [Cập nhật](#cập-nhật), [ISC Arena](
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> o4-mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5 Mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=stepfun.com&sz=32" width="14"> Step 3.5 Flash | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/blob/main/experiment/isc_single/result_direct/stepfun-step-3.5-flash/aiml_detoxify.json) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=32" width="14"> Mistral Large | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/mistral-large-deepfake) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=amazon.com&sz=32" width="14"> Amazon Nova Pro | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/amazon-nova-pro-sentiment) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=meta.com&sz=32" width="14"> Llama 4 Scout | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/llama4scout-phishing) | [@wuyoscar](https://github.com/wuyoscar) |
 
 </details>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -275,6 +275,9 @@ You are an autonomous agent solving NLP tasks. You can use terminal commands to 
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> o4-mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=openai.com&sz=32" width="14"> GPT-5 Mini | 🟢 |  |  |
 | <img src="https://www.google.com/s2/favicons?domain=stepfun.com&sz=32" width="14"> Step 3.5 Flash | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/blob/main/experiment/isc_single/result_direct/stepfun-step-3.5-flash/aiml_detoxify.json) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=mistral.ai&sz=32" width="14"> Mistral Large | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/mistral-large-deepfake) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=amazon.com&sz=32" width="14"> Amazon Nova Pro | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/amazon-nova-pro-sentiment) | [@wuyoscar](https://github.com/wuyoscar) |
+| <img src="https://www.google.com/s2/favicons?domain=meta.com&sz=32" width="14"> Llama 4 Scout | 🔴 | [🔗](https://github.com/wuyoscar/ISC-Bench/tree/main/community/llama4scout-phishing) | [@wuyoscar](https://github.com/wuyoscar) |
 
 </details>
 

--- a/assets/arena_cache.json
+++ b/assets/arena_cache.json
@@ -467,5 +467,26 @@
     "org": "StepFun",
     "score": 1389,
     "domain": "stepfun.com"
+  },
+  {
+    "rank": 68,
+    "name": "mistral-large",
+    "org": "Mistral",
+    "score": 1388,
+    "domain": "mistral.ai"
+  },
+  {
+    "rank": 69,
+    "name": "amazon-nova-pro",
+    "org": "Amazon",
+    "score": 1387,
+    "domain": "amazon.com"
+  },
+  {
+    "rank": 70,
+    "name": "llama-4-scout",
+    "org": "Meta",
+    "score": 1386,
+    "domain": "meta.com"
   }
 ]

--- a/assets/leaderboard_progress.svg
+++ b/assets/leaderboard_progress.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="720" height="200" viewBox="0 0 720 200" font-family="'Space Grotesk','Segoe UI',sans-serif">
   <rect width="720" height="200" rx="14" fill="#F8F0F0"/>
   <text x="360.0" y="46" text-anchor="middle" font-size="22" font-weight="700" fill="#D94040" letter-spacing="2">ISC ARENA</text>
-  <text x="360.0" y="120" text-anchor="middle" font-size="78" font-weight="700" fill="#D94040">49</text>
+  <text x="360.0" y="120" text-anchor="middle" font-size="78" font-weight="700" fill="#D94040">52</text>
   <text x="360.0" y="150" text-anchor="middle" font-size="18" font-weight="600" fill="#2D2020">models triggered under ISC</text>
   <text x="360.0" y="180" text-anchor="middle" font-size="13" fill="#6B5555">@wuyoscar (59)  ·  @HanxunH (6)  ·  @zry29 (2)  ·  @fresh-ma (2)</text>
 </svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -177,7 +177,7 @@
     </div>
 
     <p class="has-text-centered has-text-grey is-size-7 mt-3">
-      100 models tracked &middot; 25 per page &middot;
+      <span id="tracked-count">models</span> tracked &middot; 25 per page &middot;
       <a href="https://github.com/wuyoscar/ISC-Bench#-isc-arena" class="has-text-danger">GitHub README &rarr;</a>
     </p>
   </div>

--- a/docs/static/js/main.js
+++ b/docs/static/js/main.js
@@ -256,6 +256,9 @@ function setupSearch() {
 
 // ====== Name Conversion ======
 const DISPLAY_NAMES = {
+  "mistral-large": "Mistral Large",
+  "amazon-nova-pro": "Amazon Nova Pro",
+  "llama-4-scout": "Llama 4 Scout",
   "claude-opus-4-8": "Claude Opus 4.8",
   "claude-opus-4-7-thinking": "Claude Opus 4.7",
   "claude-opus-4-6-thinking": "Claude Opus 4.6",

--- a/docs/static/js/main.js
+++ b/docs/static/js/main.js
@@ -194,14 +194,15 @@ function populateDemos(cases) {
 
 // ====== Update Stats ======
 function updateStats(arena, cases) {
-  const confirmed = Object.keys(cases).length;
+  // Count only tracked Arena models that are triggered — matches the leaderboard
+  // rows and the static badge (not the raw isc_cases key count, which includes
+  // historical entries no longer in the Arena).
+  const confirmed = arena.filter(m => cases[slugToDisplay(m.name)]).length;
   const total = arena.length || 100;
 
-  // Update stat cards if they exist
-  document.querySelectorAll(".stat-num").forEach(el => {
-    if (el.textContent === "56") return; // keep templates count
-    if (el.textContent === "8") return;  // keep domains count
-  });
+  // Footer "<N> models tracked" — driven by data, no hardcoded count
+  const trackedEl = document.getElementById("tracked-count");
+  if (trackedEl) trackedEl.textContent = `${total} models`;
 
   // Update arena subtitle
   const subtitle = document.querySelector("#arena .subtitle");

--- a/scripts/gen_leaderboard.py
+++ b/scripts/gen_leaderboard.py
@@ -17,7 +17,6 @@ import json
 import re
 import sys
 from pathlib import Path
-from datetime import date
 
 ROOT = Path(__file__).parent.parent
 ARENA = ROOT / "assets" / "arena_cache.json"
@@ -26,6 +25,9 @@ README = ROOT / "README.md"
 
 # Model name slug → display name overrides
 DISPLAY_NAMES: dict[str, str] = {
+    "mistral-large": "Mistral Large",
+    "amazon-nova-pro": "Amazon Nova Pro",
+    "llama-4-scout": "Llama 4 Scout",
     "claude-opus-4-8": "Claude Opus 4.8",
     "claude-opus-4-7-thinking": "Claude Opus 4.7",
     "claude-opus-4-6-thinking": "Claude Opus 4.6",
@@ -93,23 +95,6 @@ DISPLAY_NAMES: dict[str, str] = {
     "o4-mini-2025-04-16": "o4-mini",
     "gpt-5-mini-high": "GPT-5 Mini",
     "step-3.5-flash": "Step 3.5 Flash",
-}
-
-# ISC case name matching (isc_cases.json uses display names)
-ISC_NAME_MAP: dict[str, str] = {
-    "claude-opus-4-7-thinking": "Claude Opus 4.7 Thinking",
-    "claude-opus-4-6": "Claude Opus 4.6",
-    "claude-opus-4-5-20251101": "Claude Opus 4.5",
-    "claude-sonnet-4-6": "Claude Sonnet 4.6",
-    "gemini-3-pro": "Gemini 3 Pro",
-    "gpt-5.2-chat-latest-20260210": "GPT-5.2 Chat",
-    "o3-2025-04-16": "o3",
-    "grok-4.1": "Grok 4.1",
-    "kimi-k2.5-thinking": "Kimi K2.5 Thinking",
-    "qwen3-max-preview": "Qwen 3 Max Preview",
-    "deepseek-v3.2": "DeepSeek V3.2",
-    "glm-5": "GLM-5",
-    "qwen3.5-397b-a17b": "Qwen 3.5 397B",
 }
 
 


### PR DESCRIPTION
Follow-up after #101 merged — make the triggered count correct, consistent, and complete (now **52**), and finish removing the old auto-update machinery.

## What was wrong
- README + static badge showed **49** (Arena-matched), but `isc_cases` held **52** triggered models. The extra 3 were triggered historically but had **no Arena row**, so they were invisible on the board.
- The website subtitle separately showed **52** via `Object.keys(isc_cases).length`, and the footer hardcoded "100 models tracked". Three different numbers.

## Fix — every triggered model goes on the board
- **Add the 3 missing triggered models as Arena rows (🔴)**: Mistral Large, Amazon Nova Pro, Llama 4 Scout (linked to their `community/` demos). Arena 67 → 70.
- Now every `isc_cases` entry is shown; the count is a consistent **52 / 70** across README (×7), the static badge, and the website.
- `updateStats()` counts tracked-and-triggered Arena models (→ 52), not the raw key count; footer is data-driven (`<N> models` → 70). (No-op `.stat-num` block removed.)
- Remove leftover dead automation in `gen_leaderboard.py`: unused `ISC_NAME_MAP` and `date` import.

## Verification
- [x] `gen_leaderboard.py` → "52/70 ISC cases"; badge → "52 models triggered under ISC"
- [x] No `isc_cases` key missing from the board (all 52 shown)
- [x] Website (new docs + live data): subtitle "… 52 triggered so far", footer "70 models tracked", clean merged names
- [x] Manual workflow only — the auto-update GitHub Action and `leaderboard_history.json` were removed in #101; updating is now: edit data → run `gen_leaderboard.py` + `gen_leaderboard_chart.py` → commit
