### PR TITLE
Docs polish: center the ISC Arena badge + fix stale website descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for trigger submissions, template/cod
 
 ## 🏆 ISC Arena
 
-<img src="assets/leaderboard_progress.png" width="55%">
+<p align="center">
+  <img src="assets/leaderboard_progress.png" width="55%">
+</p>
 
 **Split 1**
 

--- a/README_es.md
+++ b/README_es.md
@@ -182,7 +182,9 @@ Para envío de nuevos triggers, contribuciones de plantillas y código, checklis
 
 ## 🏆 ISC Arena
 
-<img src="assets/leaderboard_progress.png" width="55%">
+<p align="center">
+  <img src="assets/leaderboard_progress.png" width="55%">
+</p>
 
 **Split 1**
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -182,7 +182,9 @@ You are an autonomous agent solving NLP tasks. You can use terminal commands to 
 
 ## 🏆 ISC Arena
 
-<img src="assets/leaderboard_progress.png" width="55%">
+<p align="center">
+  <img src="assets/leaderboard_progress.png" width="55%">
+</p>
 
 **Split 1**
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -181,7 +181,9 @@ You are an autonomous agent solving NLP tasks. You can use terminal commands to 
 
 ## 🏆 ISC Arena
 
-<img src="assets/leaderboard_progress.png" width="55%">
+<p align="center">
+  <img src="assets/leaderboard_progress.png" width="55%">
+</p>
 
 **Split 1**
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -181,7 +181,9 @@ Para submissões de triggers, contribuições de templates e código, checklist 
 
 ## 🏆 ISC Arena
 
-<img src="assets/leaderboard_progress.png" width="55%">
+<p align="center">
+  <img src="assets/leaderboard_progress.png" width="55%">
+</p>
 
 **Split 1**
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -181,7 +181,9 @@ Thêm link share xuất hiện trong [Cập nhật](#cập-nhật), [ISC Arena](
 
 ## 🏆 ISC Arena
 
-<img src="assets/leaderboard_progress.png" width="55%">
+<p align="center">
+  <img src="assets/leaderboard_progress.png" width="55%">
+</p>
 
 **Split 1**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -190,7 +190,9 @@ You are an autonomous agent solving NLP tasks. You can use terminal commands to 
 
 ## 🏆 ISC Arena
 
-<img src="assets/leaderboard_progress.png" width="55%">
+<p align="center">
+  <img src="assets/leaderboard_progress.png" width="55%">
+</p>
 
 **Split 1**
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ISC-Bench — Internal Safety Collapse in Frontier LLMs | ISC Arena</title>
-  <meta name="description" content="ISC-Bench: A benchmark for studying Internal Safety Collapse in frontier large language models. 77 scenarios across 9 domains. ISC Arena tracks ISC across 100+ frontier models.">
+  <meta name="description" content="ISC-Bench: A benchmark for studying Internal Safety Collapse in frontier large language models. 84 scenarios across 9 domains. ISC Arena tracks ISC across frontier models.">
   <meta name="keywords" content="ISC, ISC-Bench, Internal Safety Collapse, LLM Safety, Jailbreak, ISC Arena, Benchmark, TVD Framework, AI Safety, Red Teaming">
 
   <!-- Bulma + Icons -->
@@ -122,7 +122,7 @@
       ISC Arena
     </h2>
     <p class="subtitle is-5 has-text-centered has-text-grey-light mt-2 mb-5">
-      Real-time tracking of ISC across <strong>100</strong> frontier models.
+      Tracking ISC across <strong>70</strong> frontier models.
       Every <span class="has-text-danger">red dot</span> is a confirmed case.
     </p>
 
@@ -318,7 +318,7 @@
   <div class="container is-max-desktop">
     <h2 class="title is-3 has-text-centered section-heading">ISC-Bench & The TVD Framework</h2>
     <div class="content is-medium mt-4" style="max-width:700px;margin-left:auto;margin-right:auto;">
-      <p>ISC is triggered by the <strong class="has-text-danger">TVD design pattern</strong> (Task + Validator + Data). A legitimate professional task where the model must fill in harmful data to satisfy a code validator. 77 scenarios across 9 domains:</p>
+      <p>ISC is triggered by the <strong class="has-text-danger">TVD design pattern</strong> (Task + Validator + Data). A legitimate professional task where the model must fill in harmful data to satisfy a code validator. 84 scenarios across 9 domains:</p>
     </div>
 
     <!-- TVD cards -->
@@ -348,7 +348,7 @@
 
     <!-- Stats -->
     <div class="columns is-multiline">
-      <div class="column is-3"><div class="stat-card"><div class="stat-num">77</div><div class="stat-label">Scenarios</div></div></div>
+      <div class="column is-3"><div class="stat-card"><div class="stat-num">84</div><div class="stat-label">Scenarios</div></div></div>
       <div class="column is-3"><div class="stat-card"><div class="stat-num">9</div><div class="stat-label">Domains</div></div></div>
       <div class="column is-3"><div class="stat-card"><div class="stat-num">100%</div><div class="stat-label">Trigger Rate</div></div></div>
       <div class="column is-3"><div class="stat-card"><div class="stat-num">0%</div><div class="stat-label">Defense Success</div></div></div>
@@ -357,20 +357,20 @@
     <!-- Domain cards -->
     <div class="columns is-multiline mt-4">
       <div class="column is-3"><div class="domain-card"><i class="fas fa-dna"></i><h4>Comp. Biology</h4><span class="domain-count">16</span></div></div>
-      <div class="column is-3"><div class="domain-card"><i class="fas fa-flask"></i><h4>Comp. Chemistry</h4><span class="domain-count">11</span></div></div>
+      <div class="column is-3"><div class="domain-card"><i class="fas fa-flask"></i><h4>Comp. Chemistry</h4><span class="domain-count">12</span></div></div>
       <div class="column is-3"><div class="domain-card"><i class="fas fa-shield-alt"></i><h4>Cybersecurity</h4><span class="domain-count">8</span></div></div>
-      <div class="column is-3"><div class="domain-card"><i class="fas fa-pills"></i><h4>Pharmacology</h4><span class="domain-count">7</span></div></div>
-      <div class="column is-3"><div class="domain-card"><i class="fas fa-robot"></i><h4>AI Safety & ML</h4><span class="domain-count">23</span></div></div>
-      <div class="column is-3"><div class="domain-card"><i class="fas fa-heartbeat"></i><h4>Clinical Genomics</h4><span class="domain-count">3</span></div></div>
+      <div class="column is-3"><div class="domain-card"><i class="fas fa-pills"></i><h4>Pharmacology</h4><span class="domain-count">4</span></div></div>
+      <div class="column is-3"><div class="domain-card"><i class="fas fa-robot"></i><h4>AI Safety & ML</h4><span class="domain-count">26</span></div></div>
+      <div class="column is-3"><div class="domain-card"><i class="fas fa-heartbeat"></i><h4>Clinical Genomics</h4><span class="domain-count">5</span></div></div>
       <div class="column is-3"><div class="domain-card"><i class="fas fa-virus"></i><h4>Epidemiology</h4><span class="domain-count">4</span></div></div>
-      <div class="column is-3"><div class="domain-card"><i class="fas fa-broadcast-tower"></i><h4>Media & Comms</h4><span class="domain-count">4</span></div></div>
+      <div class="column is-3"><div class="domain-card"><i class="fas fa-broadcast-tower"></i><h4>Media & Comms</h4><span class="domain-count">8</span></div></div>
       <div class="column is-3"><div class="domain-card"><i class="fas fa-file-alt"></i><h4>Other</h4><span class="domain-count">1</span></div></div>
     </div>
 
     <!-- Quick Links -->
     <div class="buttons is-centered mt-5">
       <a class="button is-small is-dark" href="https://arxiv.org/abs/2603.23509"><i class="fas fa-file-pdf mr-1"></i> Paper</a>
-      <a class="button is-small is-dark" href="https://github.com/wuyoscar/ISC-Bench/tree/main/templates"><i class="fas fa-folder mr-1"></i> 77 Scenarios</a>
+      <a class="button is-small is-dark" href="https://github.com/wuyoscar/ISC-Bench/tree/main/templates"><i class="fas fa-folder mr-1"></i> 84 Scenarios</a>
       <a class="button is-small is-dark" href="https://github.com/wuyoscar/ISC-Bench/tree/main/tutorials"><i class="fas fa-book mr-1"></i> Tutorials</a>
       <a class="button is-small is-dark" href="https://github.com/wuyoscar/ISC-Bench/tree/main/experiment/isc_agent"><i class="fas fa-robot mr-1"></i> ISC-Agent</a>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -126,8 +126,8 @@
       Every <span class="has-text-danger">red dot</span> is a confirmed case.
     </p>
 
-    <!-- Progress Chart (static PNG, left-aligned) -->
-    <div class="mb-5">
+    <!-- Progress Chart (static PNG, centered) -->
+    <div class="has-text-centered mb-5">
       <img src="https://raw.githubusercontent.com/wuyoscar/ISC-Bench/main/assets/leaderboard_progress.png" alt="ISC Arena — models triggered" style="max-width:420px;width:100%">
     </div>
 

--- a/docs/static/js/main.js
+++ b/docs/static/js/main.js
@@ -207,7 +207,7 @@ function updateStats(arena, cases) {
   // Update arena subtitle
   const subtitle = document.querySelector("#arena .subtitle");
   if (subtitle) {
-    subtitle.innerHTML = `Real-time tracking of ISC across <strong>${total}</strong> frontier models.
+    subtitle.innerHTML = `Tracking ISC across <strong>${total}</strong> frontier models.
       Every <span class="has-text-danger">red dot</span> is a confirmed case.
       <strong class="has-text-danger">${confirmed}</strong> triggered so far.`;
   }

--- a/scripts/gen_leaderboard.py
+++ b/scripts/gen_leaderboard.py
@@ -152,8 +152,12 @@ LANG_HEADERS: dict[str, str] = {
     "README_vi.md": "| Mô hình | Đã kích hoạt | Liên kết | Bởi |",
 }
 
-# Left-aligned static PNG badge (no link, no SVG — opens cleanly on GitHub).
-CHART = '<img src="assets/leaderboard_progress.png" width="55%">'
+# Centered static PNG badge (no link, no SVG — opens cleanly on GitHub).
+CHART = (
+    '<p align="center">\n'
+    '  <img src="assets/leaderboard_progress.png" width="55%">\n'
+    '</p>'
+)
 
 
 def build_section(header: str, tiers: list[list[str]]) -> str:


### PR DESCRIPTION
Two docs fixes, both unmerged-safe.

## 1. Center the ISC Arena badge
Was left-aligned (large empty gap on the wide website section). Centered: `docs/index.html` chart div → `has-text-centered`; README CHART → `<p align="center">` (regenerated across all 7 READMEs). Still a plain static PNG, no link.

## 2. Fix stale website descriptions
Audited `docs/index.html` + `main.js` against current state:
- **Scenario count 77 → 84** (meta, About prose, stat card, quick-link button) — matches `templates/README.md` ("84 scenarios across 9 domains").
- **Domain cards realigned to sum 84** (AI Safety & ML 23→26, Comp. Chemistry 11→12, Pharmacology 7→4, Clinical 3→5, Media & Comms 4→8).
- **Drop "Real-time"** from the Arena subtitle (HTML + main.js) — the board is manually maintained now, not auto-updated.
- Meta: "100+ frontier models" → "frontier models" (we track 70); subtitle placeholder 100 → 70 (JS fills the live count).

### Not changed (flagged)
- `main.js` `FALLBACK_CASES` still lists pre-normalization model names; only used if the live data fetch fails. Low priority.
- `100% Trigger Rate` / `0% Defense Success` stat cards are paper claims, left as-is.
