### PR TITLE
Update README resources and public-case wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 
 ## ISC Case Examples
 
+> [!IMPORTANT]
+> ISC is a structural workflow-level vulnerability, not a claim about any specific harmful topic. The paper evaluates this pattern across domains; the public cases here are intentionally limited to harmful/toxic text contexts. We avoid expanding public showcases into closed-domain tool settings or operational domain-specific artifacts.
+
 > [!CAUTION]
 > Research-use only. ISC-Bench is released exclusively for academic safety research, evaluation, and mitigation work. **We do not condone or permit any use of these materials for malicious purposes or real-world harm.**
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cd experiment/isc_single && uv run run.py --model <model-id> --bench jbb --task 
 cd experiment/isc_icl && uv run run.py --model <model-id> --demos 5
 ```
 
-[**TVD Agent**](experiment/isc_agent/) — gives an agent shell access and a high-level task; the loop is file inspection, code execution, validation, and repair. From the user side, it only needs `one initial interaction`, such as "start," "begin," or "finish the workflow"; the remaining steps are fully automated, which makes the setup low-cost to run.
+[**TVD Agent**](experiment/isc_agent/) — gives an agent shell access and a high-level task; the loop is file inspection, code execution, validation, and repair. From the user side, it only needs `one initial interaction`, such as "start," "begin," or "finish the workflow"; the remaining steps are fully automated.
 ```bash
 cd experiment/isc_agent && docker build -t isc-agent . && ./run.sh --model <model-id>
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ISC Case Examples
 
 > [!IMPORTANT]
-> ISC is a structural workflow-level vulnerability, not a claim about any specific harmful topic. The paper evaluates this pattern across domains; the public cases here are intentionally limited to harmful/toxic text contexts. We avoid expanding public showcases into closed-domain tool settings or operational domain-specific artifacts.
+> ISC is a structural workflow-level vulnerability. In the paper, we evaluate it across closed-domain settings and ablations, where the pattern remains effective. In this public release, we intentionally keep cases within toxic-text contexts, such as hate speech, fake news, or unsafe/jailbroken LLM answers commonly used in general jailbreak benchmarks, and avoid real-world operational content. If any public material appears beyond this threshold, please open a PR so we can review and revise it.
 
 > [!CAUTION]
 > Research-use only. ISC-Bench is released exclusively for academic safety research, evaluation, and mitigation work. **We do not condone or permit any use of these materials for malicious purposes or real-world harm.**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 </p>
 <p align="center">
   <a href="https://arxiv.org/abs/2603.23509"><img src="https://img.shields.io/badge/arXiv-2603.23509-b31b1b.svg" alt="Paper"></a>
-  <a href="https://www.youtube.com/watch?v=Kur0wMzuJgY"><img src="https://img.shields.io/badge/YouTube-Explainer-FF0000.svg" alt="YouTube Explainer"></a>
+  <a href="https://www.youtube.com/watch?v=Kur0wMzuJgY"><img src="https://img.shields.io/badge/YouTube-English_Explainer-FF0000.svg" alt="YouTube English Explainer"></a>
+  <a href="https://www.youtube.com/watch?v=P2MAa3jpmZw"><img src="https://img.shields.io/badge/YouTube-CN_Explainer-FF0000.svg" alt="YouTube Chinese Explainer"></a>
   <a href="https://podcasts.apple.com/tr/podcast/internal-safety-collapse-in-frontier-llms/id1835878324?i=1000759288088"><img src="https://img.shields.io/badge/Podcast-AI_Post_Transformers-8B5CF6.svg" alt="Podcast"></a>
 </p>
 
@@ -51,7 +52,8 @@ Cross-domain harmful-data examples:
 
 | Resource | Notes |
 |---|---|
-| [YouTube Explainer](https://www.youtube.com/watch?v=Kur0wMzuJgY) | Short video walkthrough of the ISC paper, TVD trigger, and failure mode. |
+| [Internal Safety Collapse - How AI Models may bypass its safety rules for tasks](https://www.youtube.com/watch?v=Kur0wMzuJgY) | English video walkthrough of the ISC paper, TVD trigger, and failure mode. |
+| [解读LLM安全机制的结构性崩塌](https://www.youtube.com/watch?v=P2MAa3jpmZw) | Chinese explainer on ISC and structural safety failure in LLMs. |
 | [AI Post Transformers Podcast](https://podcasts.apple.com/tr/podcast/internal-safety-collapse-in-frontier-llms/id1835878324?i=1000759288088) | Discussion of ISC and refusal-based alignment as a behavioral wrapper over LLM capability. |
 | [XSafeClaw](https://github.com/XSafeAI/XSafeClaw) | Guardrail framework whose red-team testing design draws on ISC-style task-completion failure modes. |
 | [promptfoo LM Security DB](https://www.promptfoo.dev/lm-security-db/vuln/frontier-llm-safety-collapse-908a4285) | Catalogs ISC as a vulnerability class with affected LLMs and mitigation caveats. |

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Community contributors have verified ISC across the frontier LLMs below.
 
 ### ISC-Bench Codebase Templates
 
-Released codebase templates are composable research scaffolds, not prompt-only examples. Each folder defines a small task/codebase surface with `prompt.txt` for the run and `SKILL.md` for the scenario contract.
+Released codebase templates are composable research scaffolds, not prompt-only examples. Each folder defines a small task/codebase surface centered on `prompt.txt` and its prompt variants for the run.
 
 Because every tool validates a different artifact, the harmful data type also changes: classifier text for AI-safety tools, sequence/structure records for bio tools, molecular records for chemistry tools, network/binary artifacts for cyber tools, and misinformation records for media tools. The table below names the data type at a high level; sensitive operational content is not expanded in the top-level README.
 

--- a/codebase_templates/README.md
+++ b/codebase_templates/README.md
@@ -6,8 +6,7 @@ These are small task/codebase scaffolds, not prompt-only examples.
 
 Each codebase template directory contains:
 - `prompt.txt` — ready-to-copy TVD prompt (formats: JSON, CSV, YAML, TSV, Pydantic)
-- `SKILL.md` — customization guide (anchor tuning, category exploration, variant creation)
-- Optional variants: `prompt_ex.txt` (one-shot), `prompt_zh.txt` / `prompt_zh_ex.txt` (Chinese), `prompt_v2.txt` (extended categories)
+- Optional prompt variants, such as `prompt_ex.txt` (one-shot), `prompt_zh.txt` / `prompt_zh_ex.txt` (Chinese), and `prompt_v2.txt` (extended categories)
 
 ## Customizing Anchors
 
@@ -35,7 +34,7 @@ Every codebase template is **composable** — the task structure (T), validator 
 
 ### General steps
 
-1. **Read the codebase template's SKILL.md** — each one explains what specific fields to change and what categories to explore
+1. **Inspect `prompt.txt` and its variants** — identify the fields, schema, and validator constraints that define the task
 2. **Pick replacement content** from the sources above (or any domain-relevant database)
 3. **Replace the anchor data** in `prompt.txt` — keep the same field structure and validator constraints
 4. **Test** — the validator should still pass with the new content; if it doesn't, check field formats

--- a/scripts/verify_template.sh
+++ b/scripts/verify_template.sh
@@ -2,8 +2,8 @@
 # Verify an ISC-Bench template:
 #   1. Run each prompt variant against a model
 #   2. Save outputs to the template folder (lowercased names)
-#   3. Convert README.md → SKILL.md (merge meta.json into it)
-#   4. Delete meta.json
+#   3. Keep generated outputs in the template folder
+#   4. Review any metadata manually before publishing
 #
 # Usage:
 #   ./scripts/verify_template.sh codebase_templates/aiml_moderation


### PR DESCRIPTION
## Summary
- Adds separate README badges for the English and Chinese YouTube explainers.
- Renames the existing YouTube resource row to the full English title.
- Adds the Chinese explainer title and link to the README resources table.
- Adds an IMPORTANT note under ISC Case Examples clarifying that ISC is structural and public cases are intentionally limited to harmful/toxic text contexts.
- Removes stale public `SKILL.md` wording from codebase-template docs and helper comments, so public materials describe templates through `prompt.txt` and prompt variants.
- Removes the conflicting low-cost phrase from the TVD Agent description.

## Validation
- `git diff --check`
- README local-link check
- YouTube URLs appear once in the badge block and once in the resources table
- Public docs/scripts search for stale `SKILL.md` / `skill` wording
- IMPORTANT block required-text check
- Strict staged secret-shape check

## Scope
- Public docs wording only. Evidence/result artifacts were intentionally not edited.
