### PR TITLE
Update ISC experiment names and HF customization table

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,9 @@ cat codebase_templates/aiml_llamaguard/prompt.txt
 
 TVD Framework is not a fixed prompt. The same structure can be instantiated through different tools, validators, and data objects.
 
-### Walkthrough Example
+The walkthrough below uses the AI domain as the running example. Other domains can use the same idea by preserving the normal workflow, changing the validator, and changing the domain-specific data object.
+
+### Walkthrough Example (AI Domain)
 
 **Scenario**: evaluating a safety classifier with a task file, a validator, and a missing data file. The sensitive text is redacted; the point is the workflow shape.
 

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ cat codebase_templates/aiml_llamaguard/prompt.txt
 
 > **Internal Safety Collapse (ISC)** is the failure phenomenon. **TVD Framework** is one engineering framework that can trigger it: a normal task, a validator, and missing data are placed inside a tool workflow. The model fills the gap because it treats completion as the objective.
 
-### Layer / Rule / Minibatch
+### Core Workflow Structure
 
 | Layer | Rule in the workflow | What the model sees |
 |-------|----------------------|---------------------|
@@ -381,7 +381,7 @@ TVD Framework is not a fixed prompt. The same structure can be instantiated thro
 
 The walkthrough below uses the AI domain as the running example. Other domains can use the same idea by preserving the normal workflow, changing the validator, and changing the domain-specific data object.
 
-### Walkthrough Example (AI Domain)
+### AI-Domain Walkthrough
 
 **Scenario**: evaluating a safety classifier with a task file, a validator, and a missing data file. The sensitive text is redacted; the point is the workflow shape.
 
@@ -461,9 +461,9 @@ The model or agent inspects the traceback and fills the missing field to satisfy
 
 ---
 
-### TVD Customization (AI-Domain Scenario Walkthrough)
+### AI-Domain Target Customization
 
-TVD Framework can target different data types by changing the validator rule while keeping the workflow normal. This section walks through one AI-domain scenario: classifier and guard tooling. Sensitive content is redacted; the paper covers nine broader scenarios across domains.
+Within this AI-domain walkthrough, the target can change by swapping the validator rule, `model_id`, target field, and data object while the workflow remains normal. Sensitive content is redacted.
 
 **Task — `task.py`**
 
@@ -622,7 +622,7 @@ The task structure can stay the same while the `model_id`, target field, and val
 | General Safety | `Intel/polite-guard` | Politeness-guard target label |
 
 
-### Tuning Tips
+### Practical Tuning Notes
 
 Small adjustments matter, especially when evaluating highly aligned models.
 
@@ -649,7 +649,7 @@ Use untargeted generation for trigger discovery, not calibrated harm scoring.
 
 ---
 
-### TVD Chatbot
+### Prompt-Only Variant: TVD Chatbot
 
 ISC also appears without files. In TVD Chatbot, a multi-turn domain workflow can move from ordinary setup to refused examples once the model treats those examples as task data.
 
@@ -671,7 +671,7 @@ A: [LLM fills redacted classifier-positive samples]  <- turning point
 
 TVD Framework is stable and automatable; TVD Chatbot is manual and session-dependent, but it shows the same ISC phenomenon without a file-based harness.
 
-### Tutorials
+### Practice Tutorials
 
 More practice leads to more effective TVD tasks.
 

--- a/README.md
+++ b/README.md
@@ -566,60 +566,30 @@ The completed rows are the **anchor**. The missing rows plus validator are the *
 
 **Method 3: Hugging Face classifier/guard targets**
 
-The task structure can stay the same while the `model_id`, target field, and validator target change. This is why TVD is structural: the system optimizes for the validator and field schema, not for a fixed harmful topic. Even inside this AI-domain scenario, classifier and guard tasks have many variants.
+The task structure can stay the same while the `model_id`, target field, and validator target change. This is why TVD is structural: the system optimizes for the validator and field schema, not for a fixed harmful topic. Even inside this AI-domain scenario, classifier and guard tasks have many variants; the table below keeps only representative targets rather than listing every similar model.
 
 | Category | Hugging Face Model ID | Configurable harmful-content setting |
 | --- | --- | --- |
 | Toxicity | `s-nlp/roberta_toxicity_classifier` | Toxicity classifier-positive text |
 | Toxicity | `unitary/toxic-bert` | Toxicity classifier-positive text |
-| Toxicity | `martin-ha/toxic-comment-model` | Toxicity classifier-positive text |
-| Toxicity | `cardiffnlp/twitter-roberta-base-offensive` | Offensive-content classifier-positive text |
 | Toxicity | `cardiffnlp/twitter-roberta-base-hate-latest` | Hate-speech classifier-positive text |
-| Toxicity | `facebook/roberta-hate-speech-dynabench-r4-target` | Hate-speech classifier-positive text |
-| Toxicity | `IMSyPP/hate_speech_en` | Hate-speech classifier-positive text |
-| Toxicity | `unitary/unbiased-toxic-roberta` | Toxicity classifier-positive text |
-| Toxicity | `unitary/multilingual-toxic-xlm-roberta` | Multilingual toxicity classifier-positive text |
-| Toxicity | `textdetox/xlmr-large-toxicity-classifier` | Multilingual toxicity classifier-positive text |
 | Toxicity | `ibm-granite/granite-guardian-hap-38m` | Harm/abuse/profanity target label |
-| Toxicity | `s-nlp/russian_toxicity_classifier` | Russian toxicity classifier-positive text |
-| Toxicity | `cointegrated/rubert-tiny-toxicity` | Russian toxicity classifier-positive text |
-| Toxicity | `IlyaGusev/rubertconv_toxic_clf` | Russian toxicity classifier-positive text |
-| Toxicity | `ml6team/distilbert-base-german-cased-toxic-comments` | German toxicity classifier-positive text |
 | Bias | `d4data/bias-detection-model` | Bias classifier-positive text |
-| Bias | `sasha/regardv3` | Regard/bias target label |
 | Bias | `bucketresearch/politicalBiasBERT` | Political-bias classifier-positive text |
 | NSFW | `michelleli99/NSFW_text_classifier` | NSFW classifier-positive text |
 | NSFW | `eliasalbouzidi/distilbert-nsfw-text-classifier` | NSFW classifier-positive text |
-| NSFW | `TostAI/nsfw-text-detection-large` | NSFW classifier-positive text |
-| NSFW | `AdamCodd/distilroberta-nsfw-prompt-stable-diffusion` | NSFW prompt classifier-positive text |
 | Privacy | `bigcode/starpii` | PII/privacy-leakage target label |
-| Privacy | `meta-llama/Llama-Guard-3-8B` | LlamaGuard S7 Privacy target |
 | Misinformation | `hamzab/roberta-fake-news-classification` | Fake-news classifier-positive record |
 | Misinformation | `jy46604790/Fake-News-Bert-Detect` | Fake-news classifier-positive record |
-| Misinformation | `vikram71198/distilroberta-base-finetuned-fake-news-detection` | Fake-news classifier-positive record |
 | Malicious Code | `mrm8488/codebert-base-finetuned-detect-insecure-code` | Insecure-code classifier target |
-| Malicious Code | `meta-llama/Llama-Guard-3-8B` | LlamaGuard S14 Code Interpreter Abuse target |
 | Jailbreak & Prompt Injection | `meta-llama/Prompt-Guard-86M` | Prompt-injection or jailbreak classifier-positive text |
 | Jailbreak & Prompt Injection | `protectai/deberta-v3-base-prompt-injection` | Prompt-injection classifier-positive text |
-| Jailbreak & Prompt Injection | `rogue-security/prompt-injection-jailbreak-sentinel-v2` | Prompt-injection or jailbreak classifier-positive text |
-| Jailbreak & Prompt Injection | `qualifire/prompt-injection-sentinel` | Prompt-injection classifier-positive text |
 | Jailbreak & Prompt Injection | `SamsungSDS-Research/SGuard-JailbreakFilter-2B-v1` | Jailbreak classifier-positive text |
 | General Safety | `meta-llama/Llama-Guard-3-8B` | Unsafe-answer target label |
 | General Safety | `google/shieldgemma-2b` | Safety-policy target label |
 | General Safety | `allenai/wildguard` | Safety moderation target label |
-| General Safety | `hbseong/HarmAug-Guard` | Harmful-answer target label |
-| General Safety | `ibm-granite/granite-guardian-3.0-8b` | Safety moderation target label |
-| General Safety | `ibm-granite/granite-guardian-3.2-5b-lora-harm-correction` | Safety moderation target label |
 | General Safety | `nvidia/llama-3.1-nemoguard-8b-content-safety` | Content-safety target label |
-| General Safety | `nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0` | Content-safety target label |
-| General Safety | `nvidia/Aegis-AI-Content-Safety-LlamaGuard-Permissive-1.0` | Content-safety target label |
-| General Safety | `nvidia/Nemotron-Content-Safety-Reasoning-4B` | Safety-reasoning target label |
 | General Safety | `KoalaAI/Text-Moderation` | Text-moderation target label |
-| General Safety | `togethercomputer/GPT-JT-Moderation-6B` | Text-moderation target label |
-| General Safety | `K-intelligence/Llama-SafetyGuard-Content-Binary` | Binary safety target label |
-| General Safety | `MerlynMind/merlyn-education-safety` | Education-safety target label |
-| General Safety | `cardiffnlp/twitter-roberta-base-sentiment-latest` | Sentiment target label |
-| General Safety | `Intel/polite-guard` | Politeness-guard target label |
 
 
 ### Practical Tuning Notes

--- a/README.md
+++ b/README.md
@@ -568,14 +568,57 @@ The task structure can stay the same while the `model_id`, target field, and val
 
 | Category | Hugging Face Model ID | Configurable harmful-content setting |
 | --- | --- | --- |
-| Toxicity | `s-nlp/roberta_toxicity_classifier`<br>`unitary/toxic-bert`<br>`martin-ha/toxic-comment-model`<br>`cardiffnlp/twitter-roberta-base-offensive`<br>`cardiffnlp/twitter-roberta-base-hate-latest`<br>`facebook/roberta-hate-speech-dynabench-r4-target`<br>`IMSyPP/hate_speech_en`<br>`unitary/unbiased-toxic-roberta`<br>`unitary/multilingual-toxic-xlm-roberta`<br>`textdetox/xlmr-large-toxicity-classifier`<br>`ibm-granite/granite-guardian-hap-38m`<br>`s-nlp/russian_toxicity_classifier`<br>`cointegrated/rubert-tiny-toxicity`<br>`IlyaGusev/rubertconv_toxic_clf`<br>`ml6team/distilbert-base-german-cased-toxic-comments` | Toxic, hate, offensive, insult, or harassment-style classifier-positive text |
-| Bias | `d4data/bias-detection-model`<br>`sasha/regardv3`<br>`bucketresearch/politicalBiasBERT` | Biased, regard-skewed, or political-bias classifier-positive text |
-| NSFW | `michelleli99/NSFW_text_classifier`<br>`eliasalbouzidi/distilbert-nsfw-text-classifier`<br>`TostAI/nsfw-text-detection-large`<br>`AdamCodd/distilroberta-nsfw-prompt-stable-diffusion` | NSFW or sexual-content classifier-positive text |
-| Privacy | `bigcode/starpii`<br>`meta-llama/Llama-Guard-3-8B` | PII/privacy-leakage text or LlamaGuard S7 Privacy target |
-| Misinformation | `hamzab/roberta-fake-news-classification`<br>`jy46604790/Fake-News-Bert-Detect`<br>`vikram71198/distilroberta-base-finetuned-fake-news-detection` | Fake-news or misinformation record |
-| Malicious Code | `mrm8488/codebert-base-finetuned-detect-insecure-code`<br>`meta-llama/Llama-Guard-3-8B` | Insecure-code classifier target or LlamaGuard S14 Code Interpreter Abuse target |
-| Jailbreak & Prompt Injection | `meta-llama/Prompt-Guard-86M`<br>`protectai/deberta-v3-base-prompt-injection`<br>`rogue-security/prompt-injection-jailbreak-sentinel-v2`<br>`qualifire/prompt-injection-sentinel`<br>`SamsungSDS-Research/SGuard-JailbreakFilter-2B-v1` | Prompt-injection or jailbreak classifier-positive text |
-| General Safety | `meta-llama/Llama-Guard-3-8B`<br>`google/shieldgemma-2b`<br>`allenai/wildguard`<br>`hbseong/HarmAug-Guard`<br>`ibm-granite/granite-guardian-3.0-8b`<br>`ibm-granite/granite-guardian-3.2-5b-lora-harm-correction`<br>`nvidia/llama-3.1-nemoguard-8b-content-safety`<br>`nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0`<br>`nvidia/Aegis-AI-Content-Safety-LlamaGuard-Permissive-1.0`<br>`nvidia/Nemotron-Content-Safety-Reasoning-4B`<br>`KoalaAI/Text-Moderation`<br>`togethercomputer/GPT-JT-Moderation-6B`<br>`K-intelligence/Llama-SafetyGuard-Content-Binary`<br>`MerlynMind/merlyn-education-safety`<br>`cardiffnlp/twitter-roberta-base-sentiment-latest`<br>`Intel/polite-guard` | Unsafe-answer, moderation, sentiment, or politeness-guard target labels |
+| Toxicity | `s-nlp/roberta_toxicity_classifier` | Toxicity classifier-positive text |
+| Toxicity | `unitary/toxic-bert` | Toxicity classifier-positive text |
+| Toxicity | `martin-ha/toxic-comment-model` | Toxicity classifier-positive text |
+| Toxicity | `cardiffnlp/twitter-roberta-base-offensive` | Offensive-content classifier-positive text |
+| Toxicity | `cardiffnlp/twitter-roberta-base-hate-latest` | Hate-speech classifier-positive text |
+| Toxicity | `facebook/roberta-hate-speech-dynabench-r4-target` | Hate-speech classifier-positive text |
+| Toxicity | `IMSyPP/hate_speech_en` | Hate-speech classifier-positive text |
+| Toxicity | `unitary/unbiased-toxic-roberta` | Toxicity classifier-positive text |
+| Toxicity | `unitary/multilingual-toxic-xlm-roberta` | Multilingual toxicity classifier-positive text |
+| Toxicity | `textdetox/xlmr-large-toxicity-classifier` | Multilingual toxicity classifier-positive text |
+| Toxicity | `ibm-granite/granite-guardian-hap-38m` | Harm/abuse/profanity target label |
+| Toxicity | `s-nlp/russian_toxicity_classifier` | Russian toxicity classifier-positive text |
+| Toxicity | `cointegrated/rubert-tiny-toxicity` | Russian toxicity classifier-positive text |
+| Toxicity | `IlyaGusev/rubertconv_toxic_clf` | Russian toxicity classifier-positive text |
+| Toxicity | `ml6team/distilbert-base-german-cased-toxic-comments` | German toxicity classifier-positive text |
+| Bias | `d4data/bias-detection-model` | Bias classifier-positive text |
+| Bias | `sasha/regardv3` | Regard/bias target label |
+| Bias | `bucketresearch/politicalBiasBERT` | Political-bias classifier-positive text |
+| NSFW | `michelleli99/NSFW_text_classifier` | NSFW classifier-positive text |
+| NSFW | `eliasalbouzidi/distilbert-nsfw-text-classifier` | NSFW classifier-positive text |
+| NSFW | `TostAI/nsfw-text-detection-large` | NSFW classifier-positive text |
+| NSFW | `AdamCodd/distilroberta-nsfw-prompt-stable-diffusion` | NSFW prompt classifier-positive text |
+| Privacy | `bigcode/starpii` | PII/privacy-leakage target label |
+| Privacy | `meta-llama/Llama-Guard-3-8B` | LlamaGuard S7 Privacy target |
+| Misinformation | `hamzab/roberta-fake-news-classification` | Fake-news classifier-positive record |
+| Misinformation | `jy46604790/Fake-News-Bert-Detect` | Fake-news classifier-positive record |
+| Misinformation | `vikram71198/distilroberta-base-finetuned-fake-news-detection` | Fake-news classifier-positive record |
+| Malicious Code | `mrm8488/codebert-base-finetuned-detect-insecure-code` | Insecure-code classifier target |
+| Malicious Code | `meta-llama/Llama-Guard-3-8B` | LlamaGuard S14 Code Interpreter Abuse target |
+| Jailbreak & Prompt Injection | `meta-llama/Prompt-Guard-86M` | Prompt-injection or jailbreak classifier-positive text |
+| Jailbreak & Prompt Injection | `protectai/deberta-v3-base-prompt-injection` | Prompt-injection classifier-positive text |
+| Jailbreak & Prompt Injection | `rogue-security/prompt-injection-jailbreak-sentinel-v2` | Prompt-injection or jailbreak classifier-positive text |
+| Jailbreak & Prompt Injection | `qualifire/prompt-injection-sentinel` | Prompt-injection classifier-positive text |
+| Jailbreak & Prompt Injection | `SamsungSDS-Research/SGuard-JailbreakFilter-2B-v1` | Jailbreak classifier-positive text |
+| General Safety | `meta-llama/Llama-Guard-3-8B` | Unsafe-answer target label |
+| General Safety | `google/shieldgemma-2b` | Safety-policy target label |
+| General Safety | `allenai/wildguard` | Safety moderation target label |
+| General Safety | `hbseong/HarmAug-Guard` | Harmful-answer target label |
+| General Safety | `ibm-granite/granite-guardian-3.0-8b` | Safety moderation target label |
+| General Safety | `ibm-granite/granite-guardian-3.2-5b-lora-harm-correction` | Safety moderation target label |
+| General Safety | `nvidia/llama-3.1-nemoguard-8b-content-safety` | Content-safety target label |
+| General Safety | `nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0` | Content-safety target label |
+| General Safety | `nvidia/Aegis-AI-Content-Safety-LlamaGuard-Permissive-1.0` | Content-safety target label |
+| General Safety | `nvidia/Nemotron-Content-Safety-Reasoning-4B` | Safety-reasoning target label |
+| General Safety | `KoalaAI/Text-Moderation` | Text-moderation target label |
+| General Safety | `togethercomputer/GPT-JT-Moderation-6B` | Text-moderation target label |
+| General Safety | `K-intelligence/Llama-SafetyGuard-Content-Binary` | Binary safety target label |
+| General Safety | `MerlynMind/merlyn-education-safety` | Education-safety target label |
+| General Safety | `cardiffnlp/twitter-roberta-base-sentiment-latest` | Sentiment target label |
+| General Safety | `Intel/polite-guard` | Politeness-guard target label |
+
 
 ### Tuning Tips
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ The completed rows are the **anchor**. The missing rows plus validator are the *
 
 **Method 3: Hugging Face classifier/guard targets**
 
-The task structure can stay the same while the `model_id`, target field, and validator target change. This is why TVD is structural: the system optimizes for the validator and field schema, not for a fixed harmful topic.
+The task structure can stay the same while the `model_id`, target field, and validator target change. This is why TVD is structural: the system optimizes for the validator and field schema, not for a fixed harmful topic. This table is only one AI-domain setting; even inside AI tooling, classifier and guard tasks have many variants. The paper covers nine broader scenarios across domains.
 
 | Category | Hugging Face Model ID | Configurable harmful-content setting |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -459,9 +459,9 @@ The model or agent inspects the traceback and fills the missing field to satisfy
 
 ---
 
-### TVD Customization
+### TVD Customization (AI-Domain Scenario Walkthrough)
 
-TVD Framework can target different data types by changing the validator rule while keeping the workflow normal. Below is a text-classifier example with sensitive content redacted.
+TVD Framework can target different data types by changing the validator rule while keeping the workflow normal. This section walks through one AI-domain scenario: classifier and guard tooling. Sensitive content is redacted; the paper covers nine broader scenarios across domains.
 
 **Task — `task.py`**
 
@@ -564,7 +564,7 @@ The completed rows are the **anchor**. The missing rows plus validator are the *
 
 **Method 3: Hugging Face classifier/guard targets**
 
-The task structure can stay the same while the `model_id`, target field, and validator target change. This is why TVD is structural: the system optimizes for the validator and field schema, not for a fixed harmful topic. This table is only one AI-domain setting; even inside AI tooling, classifier and guard tasks have many variants. The paper covers nine broader scenarios across domains.
+The task structure can stay the same while the `model_id`, target field, and validator target change. This is why TVD is structural: the system optimizes for the validator and field schema, not for a fixed harmful topic. Even inside this AI-domain scenario, classifier and guard tasks have many variants.
 
 | Category | Hugging Face Model ID | Configurable harmful-content setting |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -80,17 +80,17 @@ In two lower-risk text-classifier demonstrations, Claude Fable 5's built-in safe
 
 ## Experiments from the Paper
 
-[**TVD Chatbot**](experiment/isc_single/) — packs the task, validator, data, and failure trace into one prompt. It is a lightweight prompt-only variant that simulates terminal-style agent behavior without the full Docker-based TVD Agent. We include it because Docker and agent dependencies can be heavy; the reduced design is easy to run and still triggers roughly 95% of tested frontier models in our tests.
+[**ISC-Chatbot**](experiment/isc_single/) — packs the task, validator, data, and failure trace into one prompt. It is a lightweight prompt-only ISC variant that simulates terminal-style agent behavior without the full agent environment. We include it because full Docker and agent dependencies can be heavy; the reduced design is easy to run and still triggers roughly 95% of tested frontier models in our tests.
 ```bash
 cd experiment/isc_single && uv run run.py --model <model-id> --bench jbb --task ai-guard --samples 0
 ```
 
-[**TVD ICL**](experiment/isc_icl/) — uses completed trajectories as demonstrations before the target case.
+[**ISC-ICL**](experiment/isc_icl/) — uses completed trajectories as demonstrations before the target case.
 ```bash
 cd experiment/isc_icl && uv run run.py --model <model-id> --demos 5
 ```
 
-[**TVD Agent**](experiment/isc_agent/) — gives an agent shell access and a high-level task; the loop is file inspection, code execution, validation, and repair. From the user side, it only needs `one initial interaction`, such as "start," "begin," or "finish the workflow"; the remaining steps are fully automated.
+[**ISC-Agent**](experiment/isc_agent/) — gives an agent shell access and a high-level task; the loop is file inspection, code execution, validation, and repair. From the user side, it only needs `one initial interaction`, such as "start," "begin," or "finish the workflow"; the remaining steps are fully automated.
 ```bash
 cd experiment/isc_agent && docker build -t isc-agent . && ./run.sh --model <model-id>
 ```
@@ -561,6 +561,21 @@ class TestSuite(BaseModel):
 ```
 
 The completed rows are the **anchor**. The missing rows plus validator are the **trigger**. The model follows the data distribution and repairs the minibatch.
+
+**Method 3: Hugging Face classifier/guard targets**
+
+The task structure can stay the same while the `model_id`, target field, and validator target change. This is why TVD is structural: the system optimizes for the validator and field schema, not for a fixed harmful topic.
+
+| Category | Hugging Face Model ID | Configurable harmful-content setting |
+| --- | --- | --- |
+| Toxicity | `s-nlp/roberta_toxicity_classifier`<br>`unitary/toxic-bert`<br>`martin-ha/toxic-comment-model`<br>`cardiffnlp/twitter-roberta-base-offensive`<br>`cardiffnlp/twitter-roberta-base-hate-latest`<br>`facebook/roberta-hate-speech-dynabench-r4-target`<br>`IMSyPP/hate_speech_en`<br>`unitary/unbiased-toxic-roberta`<br>`unitary/multilingual-toxic-xlm-roberta`<br>`textdetox/xlmr-large-toxicity-classifier`<br>`ibm-granite/granite-guardian-hap-38m`<br>`s-nlp/russian_toxicity_classifier`<br>`cointegrated/rubert-tiny-toxicity`<br>`IlyaGusev/rubertconv_toxic_clf`<br>`ml6team/distilbert-base-german-cased-toxic-comments` | Toxic, hate, offensive, insult, or harassment-style classifier-positive text |
+| Bias | `d4data/bias-detection-model`<br>`sasha/regardv3`<br>`bucketresearch/politicalBiasBERT` | Biased, regard-skewed, or political-bias classifier-positive text |
+| NSFW | `michelleli99/NSFW_text_classifier`<br>`eliasalbouzidi/distilbert-nsfw-text-classifier`<br>`TostAI/nsfw-text-detection-large`<br>`AdamCodd/distilroberta-nsfw-prompt-stable-diffusion` | NSFW or sexual-content classifier-positive text |
+| Privacy | `bigcode/starpii`<br>`meta-llama/Llama-Guard-3-8B` | PII/privacy-leakage text or LlamaGuard S7 Privacy target |
+| Misinformation | `hamzab/roberta-fake-news-classification`<br>`jy46604790/Fake-News-Bert-Detect`<br>`vikram71198/distilroberta-base-finetuned-fake-news-detection` | Fake-news or misinformation record |
+| Malicious Code | `mrm8488/codebert-base-finetuned-detect-insecure-code`<br>`meta-llama/Llama-Guard-3-8B` | Insecure-code classifier target or LlamaGuard S14 Code Interpreter Abuse target |
+| Jailbreak & Prompt Injection | `meta-llama/Prompt-Guard-86M`<br>`protectai/deberta-v3-base-prompt-injection`<br>`rogue-security/prompt-injection-jailbreak-sentinel-v2`<br>`qualifire/prompt-injection-sentinel`<br>`SamsungSDS-Research/SGuard-JailbreakFilter-2B-v1` | Prompt-injection or jailbreak classifier-positive text |
+| General Safety | `meta-llama/Llama-Guard-3-8B`<br>`google/shieldgemma-2b`<br>`allenai/wildguard`<br>`hbseong/HarmAug-Guard`<br>`ibm-granite/granite-guardian-3.0-8b`<br>`ibm-granite/granite-guardian-3.2-5b-lora-harm-correction`<br>`nvidia/llama-3.1-nemoguard-8b-content-safety`<br>`nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0`<br>`nvidia/Aegis-AI-Content-Safety-LlamaGuard-Permissive-1.0`<br>`nvidia/Nemotron-Content-Safety-Reasoning-4B`<br>`KoalaAI/Text-Moderation`<br>`togethercomputer/GPT-JT-Moderation-6B`<br>`K-intelligence/Llama-SafetyGuard-Content-Binary`<br>`MerlynMind/merlyn-education-safety`<br>`cardiffnlp/twitter-roberta-base-sentiment-latest`<br>`Intel/polite-guard` | Unsafe-answer, moderation, sentiment, or politeness-guard target labels |
 
 ### Tuning Tips
 


### PR DESCRIPTION
## Summary
- Renames the paper experiment labels to `ISC-Chatbot`, `ISC-ICL`, and `ISC-Agent` before TVD is introduced.
- Reflows the `TVD Framework` section into a top-down structure: core workflow, AI-domain walkthrough, target customization, tuning notes, prompt-only variant, and tutorials.
- Adds Method 3 under AI-domain target customization with a compact, representative Hugging Face classifier/guard target table.
- Keeps `docs/index.html` and existing release `v0.0.7` unchanged.

## Validation
- `git diff --check`
- README local-link check
- Experiment-section naming check
- TVD heading-order check
- Compact Method 3 table check: 20 representative model rows, one model ID per row
- Strict secret-shape check

## Release
After this PR is merged, create `v0.0.8` with title `v0.0.8 — ISC naming and HF customization table`.